### PR TITLE
Show SUSEConnect command for package - GH2

### DIFF
--- a/zypper-search-packages
+++ b/zypper-search-packages
@@ -123,7 +123,12 @@ params.each do |pkg_name|
       p_id = product["identifier"]
       p_edition = product["edition"]
       p_arch = product["architecture"]
-      results.push([name, version, release, arch, p_id, p_name, p_edition, p_arch])
+      p_free = product["free"]
+      p_connect_string = "SUSEConnect --product #{p_id}"
+      unless p_free
+        p_connect_string += " -r ADDITIONAL REGCODE"
+      end
+      results.push([name, version, release, arch, p_id, p_name, p_edition, p_arch, p_free, p_connect_string])
     end
   end
 end
@@ -166,12 +171,12 @@ if options[:details]
   }
 else
   results.map! { | entry |
-    [ entry[0], entry[5] ]
+    [ entry[0], entry[5], entry[9].to_s ]
   }
 end
 results.uniq!
 
-header = ["Package", "Module or Repository"]
+header = ["Package", "Module or Repository", "SUSEConnect Activation Command"]
 if options[:group_by_module]
   modules = {}
   results.each do | entry |
@@ -190,7 +195,7 @@ if options[:group_by_module]
 end
 #else
   results.unshift header
-  max_lengths = [0, 0]
+  max_lengths = header.size.times.map {0}
   results.each do |x|
     x.each_with_index do |e, i|
       s = e.size


### PR DESCRIPTION
I started an implementation to show the SUSEConnect activation command for the user. This should help solve #2, an issue that we feel is important to customers.

It adds a third column to the default results, `SUSEConnect Activation Command`, the command a user needs to add the module.

```
Package              Module or Repository         SUSEConnect Activation Command                                 
-------------------  ---------------------------  ---------------------------------------------------------------
gvim                 Desktop Applications Module  SUSEConnect --product sle-module-desktop-applications/15/x86_64
texlive-context-vim  Desktop Applications Module  SUSEConnect --product sle-module-desktop-applications/15/x86_64
vim                  Basesystem Module            SUSEConnect --product sle-module-basesystem/15/x86_64          
vim-data             Basesystem Module            SUSEConnect --product sle-module-basesystem/15/x86_64          
vim-data-common      Basesystem Module            SUSEConnect --product sle-module-basesystem/15/x86_64          
vim-plugin-conky     Desktop Applications Module  SUSEConnect --product sle-module-desktop-applications/15/x86_64
vim-plugin-devhelp   Development Tools Module     SUSEConnect --product sle-module-development-tools/15/x86_64   
vim                  Installed                                                                                   
vim-data-common      Installed                                                                                   
vim                  Available                                                                                   
vim-data             Available                                                                                   
vim-data-common      Available                                                                                   
```

@jsrain Do you have any thoughts?