### PR TITLE
Match CLI arguments with `zypper search`

### DIFF
--- a/zypper-search-packages
+++ b/zypper-search-packages
@@ -225,7 +225,7 @@ begin
     opts.on("--no-query-local", "Do not search installed packages and packages in available repositories.") do |a|
       options[:no_local_repos] = true
     end
-    opts.on("-d", "--details", "Display more detailed information about found packages") do |a|
+    opts.on("-s", "--details", "Display more detailed information about found packages") do |a|
       options[:details] = a
     end
     opts.on("-v", "--verbose", "Display more detailed information about found packages") do |a|

--- a/zypper-search-packages.8
+++ b/zypper-search-packages.8
@@ -34,7 +34,7 @@ Group the results by module (default: group by package)
 .B --no-query-local
 Do not search installed packages and packages in available repositories.
 .TP
-.B -d, --details
+.B -s, --details
 Display more detailed information about found packages
 .TP
 .B --xmlout


### PR DESCRIPTION
The `-d` short option overlapped between `--details` and
`--search-descriptions`. This was fixed by changing `--details` to `-s`
which matches `zypper search`.