### PR TITLE
Fix repo/module sorting CLI

### DIFF
--- a/zypper-search-packages
+++ b/zypper-search-packages
@@ -334,7 +334,7 @@ elsif options[:sort_by_name]
   results.sort! { | a, b |
     a[0] <=> b[0]
   }
-elsif options[:sort_by_module]
+elsif options[:sort_by_repo]
   results.sort! { | a, b |
     a[1] <=> b[1]
   }


### PR DESCRIPTION
The CLI option was `:sort_by_repo` while sorting code checked `:sort_by_module` which was not attached to anything.
